### PR TITLE
Fix eval with new Cargo.lock format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# `import-cargo`
+
+Simple [flake](https://www.tweag.io/blog/2020-05-25-flakes/) to import all dependencies from
+a [`Cargo.lock`](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)
+as [fixed-output derivation](https://nixos.org/nix/manual/#fixed-output-drvs) using the
+checksum and URL from the lockfile.
+
+## Usage
+
+This example demonstrates how to build a local Cargo project with a
+`flake.nix`:
+
+``` nix
+{
+  description = "My Rust project";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-20.03;
+    import-cargo.url = github:edolstra/import-cargo;
+  };
+
+  outputs = { self, nixpkgs, import-cargo }: let
+
+    inherit (import-cargo.builders) importCargo;
+
+  in {
+
+    defaultPackage.x86_64-linux =
+      with import nixpkgs { system = "x86_64-linux"; };
+      stdenv.mkDerivation {
+        name = "testrust";
+        src = self;
+
+        nativeBuildInputs = [
+          # setupHook which makes sure that a CARGO_HOME with vendored dependencies
+          # exists
+          (importCargo { lockFile = ./Cargo.lock; inherit pkgs; }).cargoHome
+
+          # Build-time dependencies
+          rustc cargo
+        ];
+
+        buildPhase = ''
+          cargo build --release --offline
+        '';
+
+        installPhase = ''
+          install -Dm775 ./target/release/testrust $out/bin/testrust
+        '';
+
+      };
+
+  };
+}
+```

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,7 @@
         # because then we end up with a runtime dependency on it.
         cargoHome = pkgs.makeSetupHook {}
           (pkgs.writeScript "make-cargo-home" ''
-            if [[ -z $CARGO_HOME || $CARGO_HOME = /build ]]; then
+            if [[ -z "''${CARGO_HOME-}" || "''${CARGO_HOME-}" = /build ]]; then
               export CARGO_HOME=$TMPDIR/vendor
               # FIXME: work around Rust 1.36 wanting a $CARGO_HOME/.package-cache file.
               #ln -s ${vendorDir}/vendor $CARGO_HOME

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,4 @@
 {
-  edition = 201909;
-
   description = "A function for fetching the crates listed in a Cargo lock file";
 
   outputs = { self }: rec {
@@ -21,7 +19,7 @@
 
             if pkg.source == registry then
               let
-                sha256 = lockFile'.metadata."checksum ${pkg.name} ${pkg.version} (${registry})";
+                sha256 = pkg.checksum or lockFile'.metadata."checksum ${pkg.name} ${pkg.version} (${registry})";
                 tarball = import <nix/fetchurl.nix> {
                   url = "https://crates.io/api/v1/crates/${pkg.name}/${pkg.version}/download";
                   inherit sha256;


### PR DESCRIPTION
* New Cargo.lock format has checksums `[[package]]`-section
* Fixed quoting in the setup-hook, until now it errored with `unbound variable`
* Removed `edition` field
* Added readme with an example