### PR TITLE
Improve registry and git based dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,11 +59,12 @@
                   inherit url rev;
                   allRefs = true; 
                 };
+                isInner = ((fromTOML (builtins.readFile (tree  + /Cargo.toml))).package or {}).name != pkg.name;
               in pkgs.runCommand "${pkg.name}-${pkg.version}" {}
                 ''
                   tree=${tree}
 
-                  if grep --quiet '\[workspace\]' $tree/Cargo.toml; then
+                  if ${if isInner then "true" else "false"} || grep --quiet 'name = \[workspace\]' $tree/Cargo.toml; then
                     if [[ -e $tree/${pkg.name} ]]; then
                       tree=$tree/${pkg.name}
                     fi

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,10 @@
               let
                 rev = builtins.elemAt isGit 1;
                 url = builtins.elemAt isGit 0;
-                tree = builtins.fetchGit { inherit url rev; };
+                tree = builtins.fetchGit { 
+                  inherit url rev;
+                  allRefs = true; 
+                };
               in pkgs.runCommand "${pkg.name}-${pkg.version}" {}
                 ''
                   tree=${tree}


### PR DESCRIPTION
I have 2 issues when using import-cargo:
- Can't import dependencies from registries other than `crates.io`
- git dependencies doesn't have branch in Cargo.lock

This pull request is solving these issues.
- git dependencies search commit in all refs
- we can pass additional registry configuration, so custom registries would be fetched properly